### PR TITLE
重构MNav链接以使用href的已解析链接

### DIFF
--- a/docs/.vitepress/theme/components/MNavLink.vue
+++ b/docs/.vitepress/theme/components/MNavLink.vue
@@ -23,10 +23,17 @@ const svg = computed(() => {
   if (typeof props.icon === 'object') return props.icon.svg
   return ''
 })
+// 处理article链接的 base 路径
+const resolvedLink = computed(() => {
+  return withBase(props.link)
+})
 </script>
 
 <template>
-  <a v-if="link" class="m-nav-link" :href="link" target="_blank" rel="noreferrer">
+  <!-- 原先的绝对路径 -->
+  <!-- <a v-if="link" class="m-nav-link" :href="link" target="_blank" rel="noreferrer"> -->
+  <!-- 对/article/、/others/链接使用相对路径 -->
+  <a v-if="link" class="m-nav-link" :href="resolvedLink" target="_blank" rel="noreferrer">
     <article class="box">
       <div class="box-header">
         <div v-if="svg" class="icon" v-html="svg"></div>


### PR DESCRIPTION
更新了MNav链接组件，以使用已解析链接的计算属性，允许特定路由的相对路径。

这起源于一次BUG：当你没有为该仓库的GithubPage绑定域名且仓库不是主仓库（仓库名非`用户名.github.io`）时，

你的网址将会是主仓库网址后跟一个该仓库的名字作为URL，

例如我这个`WIKI`仓库的网址是www.globalvillage.广东/WIKI

但是当你在`www.globalvillage.广东/WIKI/nav`点击任意article后网址会变成`www.globalvillage.广东/article/xxx`

浏览器试图去主仓库的网址下寻找“article”这显然是不可能的

网页会404

此更新解决了这个问题